### PR TITLE
Drop accidentally included error likely used for testing

### DIFF
--- a/axios-cached-dns-resolve.js
+++ b/axios-cached-dns-resolve.js
@@ -199,7 +199,6 @@ async function resolve(host) {
   let ips
   try {
     ips = await dnsResolve(host)
-    throw new Error('test')
   } catch (e) {
     let lookupResp = await dnsLookup(host, { all: true }) // pass options all: true for all addresses
     lookupResp = extractAddresses(lookupResp)


### PR DESCRIPTION
Fairly certain this code will always use `dns.lookup` as written