### PR TITLE
Export a `reset()` function to clear active intervals

### DIFF
--- a/axios-cached-dns-resolve.js
+++ b/axios-cached-dns-resolve.js
@@ -67,6 +67,11 @@ export function init() {
   cachePruneId = setInterval(() => config.cache.purgeStale(), config.dnsIdleTtlMs)
 }
 
+export function reset() {
+  if (backgroundRefreshId) clearInterval(backgroundRefreshId)
+  if (cachePruneId) clearInterval(cachePruneId)
+}
+
 export function startBackgroundRefresh() {
   if (backgroundRefreshId) clearInterval(backgroundRefreshId)
   backgroundRefreshId = setInterval(backgroundRefresh, config.backgroundScanMs)

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ export {
   cacheConfig,
   stats,
   init,
+  reset,
   startBackgroundRefresh,
   startPeriodicCachePrune,
   getStats,


### PR DESCRIPTION
The `backgroundRefreshId` and `cachePruneId` local variables are used to create background refresh intervals behind the scenes. Unfortunately, there is no current way to clear those intervals when we want to clean things up during process termination.

This PR exposes a `reset` function that will reset these intervals.